### PR TITLE
Implement CI workflows for Rust and release package builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   rust:
     name: Rust workspace
@@ -19,14 +22,17 @@ jobs:
       - name: Install Rust components
         run: rustup component add rustfmt clippy
 
+      - name: Check lockfile
+        run: cargo metadata --locked --no-deps --format-version 1 > /dev/null
+
       - name: Check formatting
         run: cargo fmt --all --check
 
       - name: Clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --locked --workspace --all-targets -- -D warnings
 
       - name: Test
-        run: cargo test --workspace
+        run: cargo test --locked --workspace
 
       - name: Build
-        run: cargo build --workspace
+        run: cargo build --locked --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: Rust CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  rust:
+    name: Rust workspace
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install protobuf compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Install Rust components
+        run: rustup component add rustfmt clippy
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Test
+        run: cargo test --workspace
+
+      - name: Build
+        run: cargo build --workspace

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1,0 +1,162 @@
+name: Release Packages
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-package:
+    name: ${{ matrix.distro }}
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distro: debian-stable
+            container: debian:stable
+            family: deb
+            package: deb
+            arch: amd64
+          - distro: ubuntu-24.04
+            container: ubuntu:24.04
+            family: deb
+            package: deb
+            arch: amd64
+          - distro: fedora-latest
+            container: fedora:latest
+            family: rpm
+            package: rpm
+            arch: x86_64
+          - distro: rocky-9
+            container: rockylinux/rockylinux:9
+            family: rpm
+            package: rpm
+            arch: x86_64
+          - distro: opensuse-tumbleweed
+            container: opensuse/tumbleweed:latest
+            family: opensuse
+            package: rpm
+            arch: x86_64
+    env:
+      CARGO_HOME: /root/.cargo
+      RUSTUP_HOME: /root/.rustup
+      PATH: /root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+    steps:
+      - name: Install system dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          case "${{ matrix.family }}" in
+            deb)
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential ca-certificates curl dpkg-dev git liblzma-dev pkg-config protobuf-compiler
+              ;;
+            rpm)
+              dnf install -y ca-certificates curl gcc gcc-c++ git make pkgconf-pkg-config protobuf-compiler rpm xz-devel
+              ;;
+            opensuse)
+              zypper --non-interactive refresh
+              zypper --non-interactive install --no-recommends -y ca-certificates curl gcc gcc-c++ git gzip make pkg-config protobuf protobuf-devel rpm tar xz-devel
+              ;;
+          esac
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        shell: bash
+        run: |
+          set -euxo pipefail
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh
+          sh rustup-init.sh -y --profile minimal --default-toolchain stable
+
+      - name: Install Debian package tool
+        if: matrix.package == 'deb'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cargo install cargo-deb --version 3.6.3 --locked
+
+      - name: Install RPM package tool
+        if: matrix.package == 'rpm'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cargo install cargo-generate-rpm --version 0.20.0 --locked
+
+      - name: Build release binaries
+        shell: bash
+        run: cargo build --release --workspace
+
+      - name: Strip release binaries
+        shell: bash
+        run: strip target/release/wattch target/release/rapl-wattchd
+
+      - name: Build Debian package
+        if: matrix.package == 'deb'
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        shell: bash
+        run: |
+          set -euxo pipefail
+          mkdir -p dist
+          cargo deb -p wattch-cli --no-build --output "dist/wattch-${RELEASE_TAG}-${{ matrix.distro }}-${{ matrix.arch }}.deb"
+
+      - name: Build RPM package
+        if: matrix.package == 'rpm'
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        shell: bash
+        run: |
+          set -euxo pipefail
+          mkdir -p dist
+          cargo generate-rpm -p crates/wattch-cli -o "dist/wattch-${RELEASE_TAG}-${{ matrix.distro }}-${{ matrix.arch }}.rpm"
+
+      - name: Inspect Debian package
+        if: matrix.package == 'deb'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          dpkg-deb --info dist/*.deb
+          dpkg-deb --contents dist/*.deb
+
+      - name: Inspect RPM package
+        if: matrix.package == 'rpm'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          rpm -qip dist/*.rpm
+          rpm -qlp dist/*.rpm
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wattch-${{ matrix.distro }}-${{ matrix.arch }}
+          path: dist/*
+          if-no-files-found: error
+
+  upload-release-assets:
+    name: Upload release assets
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    steps:
+      - name: Download package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Upload packages to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        shell: bash
+        run: |
+          set -euxo pipefail
+          mapfile -t assets < <(find dist -type f \( -name '*.deb' -o -name '*.rpm' \) | sort)
+          gh release upload "${RELEASE_TAG}" "${assets[@]}" --clobber

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-package:
@@ -17,27 +17,27 @@ jobs:
       matrix:
         include:
           - distro: debian-stable
-            container: debian:stable
+            container: debian@sha256:e969bc4a6af81e66bf2ee7e79cecb24885929111d5eddb97dd80bed3b90a5e93
             family: deb
             package: deb
             arch: amd64
           - distro: ubuntu-24.04
-            container: ubuntu:24.04
+            container: ubuntu@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
             family: deb
             package: deb
             arch: amd64
           - distro: fedora-latest
-            container: fedora:latest
+            container: fedora@sha256:498c452f32a739b61f0ef215bce9924ebc4866cbe44710f58157d77723b7a6d2
             family: rpm
             package: rpm
             arch: x86_64
           - distro: rocky-9
-            container: rockylinux/rockylinux:9
+            container: rockylinux/rockylinux@sha256:53f4c6dcb34e1403bd93207351f0af9a593610faeb7165cb8a037346765199b0
             family: rpm
             package: rpm
             arch: x86_64
           - distro: opensuse-tumbleweed
-            container: opensuse/tumbleweed:latest
+            container: opensuse/tumbleweed@sha256:56a957fd0c4c478e7b21aa9a117d097f06609f77c22ac12ec8742be5cddd0537
             family: opensuse
             package: rpm
             arch: x86_64
@@ -91,7 +91,7 @@ jobs:
 
       - name: Build release binaries
         shell: bash
-        run: cargo build --release --workspace
+        run: cargo build --release --workspace --locked
 
       - name: Strip release binaries
         shell: bash
@@ -115,6 +115,7 @@ jobs:
         run: |
           set -euxo pipefail
           mkdir -p dist
+          # cargo-generate-rpm 0.20.0 expects the workspace member path here.
           cargo generate-rpm -p crates/wattch-cli -o "dist/wattch-${RELEASE_TAG}-${{ matrix.distro }}-${{ matrix.arch }}.rpm"
 
       - name: Inspect Debian package
@@ -144,6 +145,8 @@ jobs:
     name: Upload release assets
     runs-on: ubuntu-latest
     needs: build-package
+    permissions:
+      contents: write
 
     steps:
       - name: Download package artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 # Local runtime files
 *.sock
 *.pid
-
+.codex
 # Logs and temporary files
 *.log
 *.tmp
@@ -26,3 +26,7 @@ Thumbs.db
 .env
 .env.*
 !.env.example
+
+
+# codex
+.codex

--- a/README.md
+++ b/README.md
@@ -1,14 +1,43 @@
 
 # wattch
 
+[![Rust CI](https://github.com/chakib-belgaid/Wattch/actions/workflows/ci.yml/badge.svg)](https://github.com/chakib-belgaid/Wattch/actions/workflows/ci.yml)
+
 Wattch is a minimal local energy measurement daemon and CLI.
 
-This scaffold intentionally contains only Rust code:
+The implementation intentionally contains only Rust code:
 
 - `rapl-wattchd`: local RAPL Unix socket server and sampling loop
 - `wattch`: user-facing CLI built by the `wattch-cli` crate
 - `wattch-core`: shared framing, validation, time, and powercap helpers
 - `wattch-proto`: protobuf types generated with `prost`
+
+## Current status
+
+Wattch currently measures RAPL package/domain energy through the local `rapl-wattchd` daemon. It does not claim exact process-level or function-level attribution.
+
+The `wattch` CLI currently supports `hello`, `sources`, `stream`, and `run`.
+
+## v0.1-alpha scope
+
+v0.1-alpha is focused on the local Rust daemon, Rust CLI, protobuf framing over Unix sockets, RAPL source discovery, and deterministic tests.
+
+It intentionally excludes non-Rust clients, service APIs, dashboards, databases, report generation, AI integration, profiler integration, and plugin systems.
+
+## Release packages
+
+GitHub Releases build Linux x86_64 packages for:
+
+- Debian stable (`.deb`)
+- Ubuntu 24.04 LTS (`.deb`)
+- Fedora latest (`.rpm`)
+- Rocky Linux 9 / RHEL-compatible systems (`.rpm`)
+- openSUSE Tumbleweed (`.rpm`)
+
+The packages install:
+
+- `wattch` to `/usr/bin/wattch`
+- `rapl-wattchd` to `/usr/sbin/rapl-wattchd`
 
 ## Protocol
 
@@ -73,10 +102,10 @@ sudo ./target/debug/rapl-wattchd
 ./target/debug/wattch run --format csv -- cargo test
 ```
 
-## Verification
+## Quality gate
 
 ```sh
-cargo fmt
+cargo fmt --all --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 cargo build --workspace

--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ sudo ./target/debug/rapl-wattchd
 ## Quality gate
 
 ```sh
+cargo metadata --locked --no-deps --format-version 1 > /dev/null
 cargo fmt --all --check
-cargo clippy --workspace --all-targets -- -D warnings
-cargo test --workspace
-cargo build --workspace
+cargo clippy --locked --workspace --all-targets -- -D warnings
+cargo test --locked --workspace
+cargo build --locked --workspace
 ```

--- a/crates/wattch-cli/Cargo.toml
+++ b/crates/wattch-cli/Cargo.toml
@@ -3,10 +3,40 @@ name = "wattch-cli"
 edition.workspace = true
 license.workspace = true
 version.workspace = true
+description = "Minimal local energy measurement daemon and CLI"
+repository = "https://github.com/chakib-belgaid/Wattch"
 
 [[bin]]
 name = "wattch"
 path = "src/main.rs"
+
+[package.metadata.deb]
+name = "wattch"
+maintainer = "Wattch maintainers <noreply@github.com>"
+copyright = "2026 Wattch maintainers"
+extended-description = "Wattch measures local RAPL package/domain energy through a small Unix socket daemon and Rust CLI."
+depends = "$auto"
+section = "utils"
+priority = "optional"
+assets = [
+    ["target/release/wattch", "usr/bin/", "755"],
+    ["target/release/rapl-wattchd", "usr/sbin/", "755"],
+]
+
+[package.metadata.generate-rpm]
+name = "wattch"
+summary = "Minimal local energy measurement daemon and CLI"
+url = "https://github.com/chakib-belgaid/Wattch"
+
+[[package.metadata.generate-rpm.assets]]
+source = "target/release/wattch"
+dest = "/usr/bin/wattch"
+mode = "0755"
+
+[[package.metadata.generate-rpm.assets]]
+source = "target/release/rapl-wattchd"
+dest = "/usr/sbin/rapl-wattchd"
+mode = "0755"
 
 [dependencies]
 clap.workspace = true


### PR DESCRIPTION
Add continuous integration workflows for Rust projects and automate the building of release packages for various Linux distributions. This includes checks for code formatting, linting, testing, and packaging for Debian and RPM systems. 
closes issue #7