### PR TITLE
Define internal energy source interface

### DIFF
--- a/crates/rapl-wattchd/src/daemon.rs
+++ b/crates/rapl-wattchd/src/daemon.rs
@@ -7,8 +7,8 @@ use tokio::net::unix::OwnedWriteHalf;
 use tokio::net::UnixStream;
 use tokio::sync::{watch, Mutex};
 use wattch_core::{
-    discover_powercap_sources, read_frame_async, validate_interval_ns, validate_source_ids,
-    write_frame_async, PowercapSource, Result, ServiceConfig, WattchError,
+    discover_powercap_energy_sources, read_frame_async, validate_interval_ns, validate_source_ids,
+    write_frame_async, BoxedEnergySource, Result, ServiceConfig, SourceMetadata, WattchError,
 };
 use wattch_proto::wattch::v1::{
     request, response, Error as ProtoError, HelloResponse, ListSourcesResponse, Request, Response,
@@ -189,7 +189,7 @@ async fn handle_request(
                 return send_wattch_error(&writer, request_id, error).await;
             }
 
-            let sources = match discover_powercap_sources(&state.config.powercap_root) {
+            let sources = match discover_sources(&state.config) {
                 Ok(sources) => sources,
                 Err(error) => return send_wattch_error(&writer, request_id, error).await,
             };
@@ -198,7 +198,7 @@ async fn handle_request(
                 return send_wattch_error(&writer, request_id, error).await;
             }
 
-            let selected_sources = select_sources(&start.source_ids, &sources);
+            let selected_sources = select_sources(&start.source_ids, sources);
             handle_start_stream(
                 request_id,
                 start.interval_ns,
@@ -224,7 +224,7 @@ async fn handle_list_sources(
     state: Arc<DaemonState>,
     writer: SharedWriter,
 ) -> Result<()> {
-    let sources = match discover_powercap_sources(&state.config.powercap_root) {
+    let sources = match discover_sources(&state.config) {
         Ok(sources) => sources,
         Err(error) => return send_wattch_error(&writer, request_id, error).await,
     };
@@ -234,7 +234,7 @@ async fn handle_list_sources(
         &Response {
             request_id,
             kind: Some(response::Kind::ListSources(ListSourcesResponse {
-                sources: sources.iter().map(PowercapSource::to_proto).collect(),
+                sources: sources.iter().map(SourceMetadata::to_proto).collect(),
             })),
         },
     )
@@ -244,7 +244,7 @@ async fn handle_list_sources(
 async fn handle_start_stream(
     request_id: u64,
     interval_ns: u64,
-    sources: Vec<PowercapSource>,
+    sources: Vec<BoxedEnergySource>,
     state: Arc<DaemonState>,
     writer: SharedWriter,
 ) -> Result<()> {
@@ -328,24 +328,31 @@ async fn handle_stop_stream(
     .await
 }
 
-fn select_sources(source_ids: &[u32], sources: &[PowercapSource]) -> Vec<PowercapSource> {
+fn discover_sources(config: &DaemonConfig) -> Result<Vec<BoxedEnergySource>> {
+    discover_powercap_energy_sources(&config.powercap_root)
+}
+
+fn select_sources(
+    source_ids: &[u32],
+    mut sources: Vec<BoxedEnergySource>,
+) -> Vec<BoxedEnergySource> {
     if source_ids.is_empty() {
         return sources
-            .iter()
-            .filter(|source| source.available)
-            .cloned()
+            .into_iter()
+            .filter(|source| source.available())
             .collect();
     }
 
-    source_ids
-        .iter()
-        .filter_map(|source_id| {
-            sources
-                .iter()
-                .find(|source| source.source_id == *source_id && source.available)
-        })
-        .cloned()
-        .collect()
+    let mut selected = Vec::new();
+    for source_id in source_ids {
+        if let Some(index) = sources
+            .iter()
+            .position(|source| source.source_id() == *source_id && source.available())
+        {
+            selected.push(sources.remove(index));
+        }
+    }
+    selected
 }
 
 pub(crate) async fn send_response(writer: &SharedWriter, response: &Response) -> Result<()> {

--- a/crates/rapl-wattchd/src/sampler.rs
+++ b/crates/rapl-wattchd/src/sampler.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::watch;
-use wattch_core::{compute_delta_j, time, PowercapSource, Result};
+use wattch_core::{compute_delta_j, time, BoxedEnergySource, Result, SourceMetadata};
 use wattch_proto::wattch::v1::{response, Response, Sample};
 
 use crate::daemon::{error_response, send_response, DaemonState, SharedWriter, CODE_INTERNAL};
@@ -11,7 +11,7 @@ pub async fn run_stream(
     state: Arc<DaemonState>,
     stream_id: u64,
     writer: SharedWriter,
-    sources: Vec<PowercapSource>,
+    sources: Vec<BoxedEnergySource>,
     interval_ns: u64,
     request_id: u64,
     stop_rx: watch::Receiver<bool>,
@@ -29,7 +29,7 @@ pub async fn run_stream(
 
 async fn stream_loop(
     writer: &SharedWriter,
-    sources: &[PowercapSource],
+    sources: &[BoxedEnergySource],
     interval_ns: u64,
     request_id: u64,
     mut stop_rx: watch::Receiver<bool>,
@@ -51,13 +51,13 @@ async fn stream_loop(
                 for (source, previous) in sources.iter().zip(previous_energy.iter_mut()) {
                     let current = source.read_energy_j()?;
                     let (delta_j, counter_wrap) =
-                        compute_delta_j(*previous, current, source.max_energy_j);
+                        compute_delta_j(*previous, current, source.max_energy_j());
                     *previous = current;
 
                     let response = Response {
                         request_id,
                         kind: Some(response::Kind::Sample(Sample {
-                            source_id: source.source_id,
+                            source_id: source.source_id(),
                             monotonic_ns: time::monotonic_ns(),
                             energy_j: current,
                             delta_j,

--- a/crates/wattch-core/src/lib.rs
+++ b/crates/wattch-core/src/lib.rs
@@ -12,9 +12,10 @@ pub use errors::{Result, WattchError};
 pub use framing::{
     decode_frame, encode_frame, read_frame_async, write_frame_async, MAX_FRAME_SIZE,
 };
+pub use sources::energy::{BoxedEnergySource, EnergySource, SourceMetadata};
 pub use sources::powercap::{
-    compute_delta_j, discover_powercap_sources, microjoules_to_joules, PowercapSource,
-    PRODUCTION_POWER_CAP_ROOT,
+    compute_delta_j, discover_powercap_energy_sources, discover_powercap_sources,
+    microjoules_to_joules, PowercapSource, PRODUCTION_POWER_CAP_ROOT,
 };
 pub use summary::{SourceSummary, SummaryAggregator};
 
@@ -31,13 +32,16 @@ pub fn validate_interval_ns(interval_ns: u64) -> Result<()> {
     Ok(())
 }
 
-pub fn validate_source_ids(source_ids: &[u32], available_sources: &[PowercapSource]) -> Result<()> {
+pub fn validate_source_ids<T>(source_ids: &[u32], available_sources: &[T]) -> Result<()>
+where
+    T: SourceMetadata,
+{
     for source_id in source_ids {
         match available_sources
             .iter()
-            .find(|source| source.source_id == *source_id)
+            .find(|source| source.source_id() == *source_id)
         {
-            Some(source) if source.available => {}
+            Some(source) if source.available() => {}
             Some(_) => return Err(WattchError::SourceUnavailable(*source_id)),
             None => return Err(WattchError::SourceNotFound(*source_id)),
         }

--- a/crates/wattch-core/src/sources/energy.rs
+++ b/crates/wattch-core/src/sources/energy.rs
@@ -1,0 +1,60 @@
+use std::fmt::Debug;
+
+use wattch_proto::wattch::v1::Source;
+
+use crate::errors::Result;
+
+pub type BoxedEnergySource = Box<dyn EnergySource>;
+
+pub trait SourceMetadata {
+    fn source_id(&self) -> u32;
+
+    fn source_name(&self) -> &str;
+
+    fn kind(&self) -> &str;
+
+    fn unit(&self) -> &str;
+
+    fn available(&self) -> bool;
+
+    fn to_proto(&self) -> Source {
+        Source {
+            source_id: self.source_id(),
+            name: self.source_name().to_string(),
+            kind: self.kind().to_string(),
+            unit: self.unit().to_string(),
+            available: self.available(),
+        }
+    }
+}
+
+impl<T> SourceMetadata for Box<T>
+where
+    T: SourceMetadata + ?Sized,
+{
+    fn source_id(&self) -> u32 {
+        (**self).source_id()
+    }
+
+    fn source_name(&self) -> &str {
+        (**self).source_name()
+    }
+
+    fn kind(&self) -> &str {
+        (**self).kind()
+    }
+
+    fn unit(&self) -> &str {
+        (**self).unit()
+    }
+
+    fn available(&self) -> bool {
+        (**self).available()
+    }
+}
+
+pub trait EnergySource: SourceMetadata + Debug + Send + Sync {
+    fn read_energy_j(&self) -> Result<f64>;
+
+    fn max_energy_j(&self) -> f64;
+}

--- a/crates/wattch-core/src/sources/mod.rs
+++ b/crates/wattch-core/src/sources/mod.rs
@@ -1,1 +1,43 @@
+pub mod energy;
 pub mod powercap;
+
+pub use energy::{BoxedEnergySource, EnergySource, SourceMetadata};
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{EnergySource, SourceMetadata};
+    use crate::sources::powercap::PowercapSource;
+
+    fn powercap_source() -> PowercapSource {
+        PowercapSource {
+            source_id: 7,
+            name: "rapl:package-0".to_string(),
+            kind: "rapl".to_string(),
+            unit: "joule".to_string(),
+            available: true,
+            path: PathBuf::from("/fake"),
+            max_energy_j: 262_143.0,
+        }
+    }
+
+    #[test]
+    fn powercap_source_exposes_energy_source_interface() {
+        let source = powercap_source();
+
+        assert_eq!(SourceMetadata::source_id(&source), 7);
+        assert_eq!(SourceMetadata::source_name(&source), "rapl:package-0");
+        assert_eq!(SourceMetadata::kind(&source), "rapl");
+        assert_eq!(SourceMetadata::unit(&source), "joule");
+        assert!(SourceMetadata::available(&source));
+        assert_eq!(EnergySource::max_energy_j(&source), 262_143.0);
+
+        let proto = SourceMetadata::to_proto(&source);
+        assert_eq!(proto.source_id, 7);
+        assert_eq!(proto.name, "rapl:package-0");
+        assert_eq!(proto.kind, "rapl");
+        assert_eq!(proto.unit, "joule");
+        assert!(proto.available);
+    }
+}

--- a/crates/wattch-core/src/sources/powercap.rs
+++ b/crates/wattch-core/src/sources/powercap.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use wattch_proto::wattch::v1::Source;
 
 use crate::errors::{Result, WattchError};
+use crate::sources::energy::{BoxedEnergySource, EnergySource, SourceMetadata};
 
 pub const PRODUCTION_POWER_CAP_ROOT: &str = "/sys/devices/virtual/powercap";
 
@@ -20,17 +21,43 @@ pub struct PowercapSource {
 
 impl PowercapSource {
     pub fn to_proto(&self) -> Source {
-        Source {
-            source_id: self.source_id,
-            name: self.name.clone(),
-            kind: self.kind.clone(),
-            unit: self.unit.clone(),
-            available: self.available,
-        }
+        SourceMetadata::to_proto(self)
     }
 
     pub fn read_energy_j(&self) -> Result<f64> {
         read_energy_j(&self.path)
+    }
+}
+
+impl SourceMetadata for PowercapSource {
+    fn source_id(&self) -> u32 {
+        self.source_id
+    }
+
+    fn source_name(&self) -> &str {
+        &self.name
+    }
+
+    fn kind(&self) -> &str {
+        &self.kind
+    }
+
+    fn unit(&self) -> &str {
+        &self.unit
+    }
+
+    fn available(&self) -> bool {
+        self.available
+    }
+}
+
+impl EnergySource for PowercapSource {
+    fn read_energy_j(&self) -> Result<f64> {
+        PowercapSource::read_energy_j(self)
+    }
+
+    fn max_energy_j(&self) -> f64 {
+        self.max_energy_j
     }
 }
 
@@ -63,6 +90,13 @@ pub fn discover_powercap_sources(root: &Path) -> Result<Vec<PowercapSource>> {
     }
 
     Ok(sources)
+}
+
+pub fn discover_powercap_energy_sources(root: &Path) -> Result<Vec<BoxedEnergySource>> {
+    Ok(discover_powercap_sources(root)?
+        .into_iter()
+        .map(|source| Box::new(source) as BoxedEnergySource)
+        .collect())
 }
 
 pub fn compute_delta_j(previous: f64, current: f64, max_range: f64) -> (f64, bool) {


### PR DESCRIPTION
## Summary

- Adds an internal `EnergySource`/`SourceMetadata` interface in `wattch-core`.
- Adapts RAPL powercap sources to the interface while preserving existing RAPL discovery behavior.
- Updates daemon list/stream paths to use boxed energy sources instead of directly depending on `PowercapSource`.

Closes #11.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p wattch-core powercap_source_exposes_energy_source_interface`
- `cargo test --workspace` (outside sandbox so daemon integration tests can bind Unix sockets)
- `cargo build --workspace`