### PR TITLE
Add deterministic fake energy source

### DIFF
--- a/crates/wattch-core/src/lib.rs
+++ b/crates/wattch-core/src/lib.rs
@@ -13,6 +13,7 @@ pub use framing::{
     decode_frame, encode_frame, read_frame_async, write_frame_async, MAX_FRAME_SIZE,
 };
 pub use sources::energy::{BoxedEnergySource, EnergySource, SourceMetadata};
+pub use sources::fake::{fake_energy_sources, FakeEnergySource};
 pub use sources::powercap::{
     compute_delta_j, discover_powercap_energy_sources, discover_powercap_sources,
     microjoules_to_joules, PowercapSource, PRODUCTION_POWER_CAP_ROOT,

--- a/crates/wattch-core/src/sources/fake.rs
+++ b/crates/wattch-core/src/sources/fake.rs
@@ -1,0 +1,76 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::errors::Result;
+use crate::sources::energy::{BoxedEnergySource, EnergySource, SourceMetadata};
+
+#[derive(Debug)]
+pub struct FakeEnergySource {
+    source_id: u32,
+    name: String,
+    initial_energy_j: f64,
+    step_j: f64,
+    max_energy_j: f64,
+    reading_index: AtomicU64,
+}
+
+impl FakeEnergySource {
+    pub fn new(
+        source_id: u32,
+        name: impl Into<String>,
+        initial_energy_j: f64,
+        step_j: f64,
+        max_energy_j: f64,
+    ) -> Self {
+        Self {
+            source_id,
+            name: name.into(),
+            initial_energy_j,
+            step_j,
+            max_energy_j,
+            reading_index: AtomicU64::new(0),
+        }
+    }
+}
+
+impl SourceMetadata for FakeEnergySource {
+    fn source_id(&self) -> u32 {
+        self.source_id
+    }
+
+    fn source_name(&self) -> &str {
+        &self.name
+    }
+
+    fn kind(&self) -> &str {
+        "fake"
+    }
+
+    fn unit(&self) -> &str {
+        "joule"
+    }
+
+    fn available(&self) -> bool {
+        true
+    }
+}
+
+impl EnergySource for FakeEnergySource {
+    fn read_energy_j(&self) -> Result<f64> {
+        let index = self.reading_index.fetch_add(1, Ordering::Relaxed);
+        Ok(self.initial_energy_j + self.step_j * index as f64)
+    }
+
+    fn max_energy_j(&self) -> f64 {
+        self.max_energy_j
+    }
+}
+
+pub fn fake_energy_sources() -> Vec<BoxedEnergySource> {
+    vec![Box::new(FakeEnergySource::new(
+        1,
+        "fake:deterministic",
+        100.0,
+        5.0,
+        1_000_000.0,
+    ))]
+}

--- a/crates/wattch-core/src/sources/mod.rs
+++ b/crates/wattch-core/src/sources/mod.rs
@@ -1,13 +1,16 @@
 pub mod energy;
+pub mod fake;
 pub mod powercap;
 
 pub use energy::{BoxedEnergySource, EnergySource, SourceMetadata};
+pub use fake::{fake_energy_sources, FakeEnergySource};
 
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
 
     use super::{EnergySource, SourceMetadata};
+    use crate::sources::fake::{fake_energy_sources, FakeEnergySource};
     use crate::sources::powercap::PowercapSource;
 
     fn powercap_source() -> PowercapSource {
@@ -39,5 +42,30 @@ mod tests {
         assert_eq!(proto.kind, "rapl");
         assert_eq!(proto.unit, "joule");
         assert!(proto.available);
+    }
+
+    #[test]
+    fn fake_energy_source_returns_deterministic_energy_steps() {
+        let source = FakeEnergySource::new(1, "fake:deterministic", 100.0, 5.0, 1_000_000.0);
+
+        assert_eq!(source.read_energy_j().expect("first reading"), 100.0);
+        assert_eq!(source.read_energy_j().expect("second reading"), 105.0);
+        assert_eq!(source.read_energy_j().expect("third reading"), 110.0);
+        assert_eq!(EnergySource::max_energy_j(&source), 1_000_000.0);
+    }
+
+    #[test]
+    fn fake_energy_sources_expose_one_available_source() {
+        let sources = fake_energy_sources();
+
+        assert_eq!(sources.len(), 1);
+        assert_eq!(SourceMetadata::source_id(&sources[0]), 1);
+        assert_eq!(
+            SourceMetadata::source_name(&sources[0]),
+            "fake:deterministic"
+        );
+        assert_eq!(SourceMetadata::kind(&sources[0]), "fake");
+        assert_eq!(SourceMetadata::unit(&sources[0]), "joule");
+        assert!(SourceMetadata::available(&sources[0]));
     }
 }


### PR DESCRIPTION
## Summary

- Adds a deterministic in-memory fake energy source in `wattch-core`.
- Exposes a `fake_energy_sources()` helper returning one available joule source.
- Adds unit coverage for deterministic 100 J, 105 J, 110 J readings and source metadata.

Closes #12.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p wattch-core fake_energy_source`
- `cargo test --workspace` (outside sandbox so daemon integration tests can bind Unix sockets)
- `cargo build --workspace`