### PR TITLE
Add fake backend smoke test

### DIFF
--- a/crates/wattch-cli/tests/smoke_script.rs
+++ b/crates/wattch-cli/tests/smoke_script.rs
@@ -1,19 +1,31 @@
 use assert_cmd::Command;
 use predicates::str::is_match;
+use std::fs;
 use std::path::Path;
 
 #[test]
 fn fake_backend_smoke_script_prints_exact_success_line() {
-    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let script = manifest_dir
-        .parent()
-        .and_then(Path::parent)
-        .expect("workspace root")
-        .join("scripts/smoke_fake_backend.sh");
+    let script = smoke_script_path();
     let mut command = Command::new(script);
 
     command
         .assert()
         .success()
         .stdout(is_match("^wattch smoke test passed\n$").expect("valid regex"));
+}
+
+#[test]
+fn fake_backend_smoke_script_does_not_hard_code_cargo_target_dir() {
+    let script = fs::read_to_string(smoke_script_path()).expect("read smoke script");
+
+    assert!(!script.contains("target/debug"));
+}
+
+fn smoke_script_path() -> std::path::PathBuf {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .join("scripts/smoke_fake_backend.sh")
 }

--- a/crates/wattch-cli/tests/smoke_script.rs
+++ b/crates/wattch-cli/tests/smoke_script.rs
@@ -1,0 +1,19 @@
+use assert_cmd::Command;
+use predicates::str::is_match;
+use std::path::Path;
+
+#[test]
+fn fake_backend_smoke_script_prints_exact_success_line() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let script = manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .join("scripts/smoke_fake_backend.sh");
+    let mut command = Command::new(script);
+
+    command
+        .assert()
+        .success()
+        .stdout(is_match("^wattch smoke test passed\n$").expect("valid regex"));
+}

--- a/scripts/smoke_fake_backend.sh
+++ b/scripts/smoke_fake_backend.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/wattch-smoke.XXXXXX")
+SOCKET="$TMP_DIR/wattch.sock"
+STDOUT_LOG="$TMP_DIR/stdout.log"
+STDERR_LOG="$TMP_DIR/stderr.log"
+BUILD_LOG="$TMP_DIR/build.log"
+SOURCES_OUT="$TMP_DIR/sources.out"
+STREAM_OUT="$TMP_DIR/stream.out"
+RUN_OUT="$TMP_DIR/run.out"
+DAEMON_PID=""
+
+cleanup() {
+  if [ -n "$DAEMON_PID" ]; then
+    kill "$DAEMON_PID" 2>/dev/null || true
+    wait "$DAEMON_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT INT TERM
+
+cd "$ROOT_DIR"
+cargo build -p rapl-wattchd -p wattch-cli >"$BUILD_LOG" 2>&1
+
+WATTCH_SOCKET="$SOCKET" WATTCH_SOURCE_BACKEND=fake \
+  "$ROOT_DIR/target/debug/rapl-wattchd" >"$STDOUT_LOG" 2>"$STDERR_LOG" &
+DAEMON_PID=$!
+
+index=0
+while [ "$index" -lt 100 ]; do
+  if [ -S "$SOCKET" ]; then
+    break
+  fi
+  if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+    exit 1
+  fi
+  index=$((index + 1))
+  sleep 0.01
+done
+
+[ -S "$SOCKET" ]
+
+WATTCH_SOCKET="$SOCKET" "$ROOT_DIR/target/debug/wattch" hello >/dev/null
+WATTCH_SOCKET="$SOCKET" "$ROOT_DIR/target/debug/wattch" sources >"$SOURCES_OUT"
+grep -q "fake:deterministic" "$SOURCES_OUT"
+WATTCH_SOCKET="$SOCKET" "$ROOT_DIR/target/debug/wattch" stream --interval-ms 10 --duration 50ms --format csv >"$STREAM_OUT"
+grep -q "fake:deterministic" "$STREAM_OUT"
+WATTCH_SOCKET="$SOCKET" "$ROOT_DIR/target/debug/wattch" run --interval-ms 10 -- sh -c "sleep 0.05" >"$RUN_OUT"
+grep -q "fake:deterministic" "$RUN_OUT"
+
+printf '%s\n' "wattch smoke test passed"

--- a/scripts/smoke_fake_backend.sh
+++ b/scripts/smoke_fake_backend.sh
@@ -25,7 +25,7 @@ cd "$ROOT_DIR"
 cargo build -p rapl-wattchd -p wattch-cli >"$BUILD_LOG" 2>&1
 
 WATTCH_SOCKET="$SOCKET" WATTCH_SOURCE_BACKEND=fake \
-  "$ROOT_DIR/target/debug/rapl-wattchd" >"$STDOUT_LOG" 2>"$STDERR_LOG" &
+  cargo run --quiet -p rapl-wattchd --bin rapl-wattchd >"$STDOUT_LOG" 2>"$STDERR_LOG" &
 DAEMON_PID=$!
 
 index=0
@@ -42,12 +42,12 @@ done
 
 [ -S "$SOCKET" ]
 
-WATTCH_SOCKET="$SOCKET" "$ROOT_DIR/target/debug/wattch" hello >/dev/null
-WATTCH_SOCKET="$SOCKET" "$ROOT_DIR/target/debug/wattch" sources >"$SOURCES_OUT"
+WATTCH_SOCKET="$SOCKET" cargo run --quiet -p wattch-cli --bin wattch -- hello >/dev/null
+WATTCH_SOCKET="$SOCKET" cargo run --quiet -p wattch-cli --bin wattch -- sources >"$SOURCES_OUT"
 grep -q "fake:deterministic" "$SOURCES_OUT"
-WATTCH_SOCKET="$SOCKET" "$ROOT_DIR/target/debug/wattch" stream --interval-ms 10 --duration 50ms --format csv >"$STREAM_OUT"
+WATTCH_SOCKET="$SOCKET" cargo run --quiet -p wattch-cli --bin wattch -- stream --interval-ms 10 --duration 50ms --format csv >"$STREAM_OUT"
 grep -q "fake:deterministic" "$STREAM_OUT"
-WATTCH_SOCKET="$SOCKET" "$ROOT_DIR/target/debug/wattch" run --interval-ms 10 -- sh -c "sleep 0.05" >"$RUN_OUT"
+WATTCH_SOCKET="$SOCKET" cargo run --quiet -p wattch-cli --bin wattch -- run --interval-ms 10 -- sh -c "sleep 0.05" >"$RUN_OUT"
 grep -q "fake:deterministic" "$RUN_OUT"
 
 printf '%s\n' "wattch smoke test passed"


### PR DESCRIPTION
## Summary

- Adds `scripts/smoke_fake_backend.sh` for portable daemon/CLI smoke coverage with the deterministic fake backend.
- Verifies daemon startup, `wattch hello`, `wattch sources`, `wattch stream`, and `wattch run` through an isolated Unix socket.
- Adds a Rust integration test that asserts the script prints exactly `wattch smoke test passed` on stdout.

Closes #14.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p wattch-cli fake_backend_smoke_script_prints_exact_success_line --test smoke_script` (outside sandbox so the script can bind a daemon socket)
- `cargo test --workspace` (outside sandbox so daemon and smoke-script tests can bind Unix sockets)
- `cargo build --workspace`
- `scripts/smoke_fake_backend.sh`