### PR TITLE
Document deterministic source backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The implementation intentionally contains only Rust code:
 
 ## Current status
 
-Wattch currently measures RAPL package/domain energy through the local `rapl-wattchd` daemon. It does not claim exact process-level or function-level attribution.
+Wattch currently measures RAPL package/domain energy through the local `rapl-wattchd` daemon. It also has a deterministic fake source backend for repeatable local tests and smoke checks. It does not claim exact process-level or function-level attribution.
 
 The `wattch` CLI currently supports `hello`, `sources`, `stream`, and `run`.
 
@@ -88,6 +88,13 @@ For deterministic tests and local experiments:
 - `WATTCH_CONFIG` overrides the config file path.
 - `WATTCH_SOCKET` overrides the socket path.
 - `WATTCH_POWER_CAP_ROOT` overrides the powercap root.
+- `WATTCH_SOURCE_BACKEND` selects the daemon source backend:
+  - unset, `powercap`, or `rapl`: discover real Linux powercap/RAPL sources.
+  - `fake`: use one deterministic in-memory source named `fake:deterministic`.
+
+The fake backend is configured only on the daemon process. The CLI only needs to point at the same Unix socket. The fake source does not require root or a Linux powercap sysfs tree.
+
+Full details are in [docs/deterministic-source.md](docs/deterministic-source.md).
 
 ## Commands
 
@@ -100,6 +107,31 @@ sudo ./target/debug/rapl-wattchd
 ./target/debug/wattch stream --interval-ms 100 --duration 5s --format table
 ./target/debug/wattch run -- cargo test
 ./target/debug/wattch run --format csv -- cargo test
+```
+
+Deterministic fake backend example:
+
+```sh
+cargo build -p rapl-wattchd -p wattch-cli
+
+export WATTCH_SOCKET=/tmp/wattch-fake.sock
+rm -f "$WATTCH_SOCKET"
+WATTCH_SOURCE_BACKEND=fake cargo run --quiet -p rapl-wattchd --bin rapl-wattchd
+```
+
+In another terminal:
+
+```sh
+export WATTCH_SOCKET=/tmp/wattch-fake.sock
+cargo run --quiet -p wattch-cli --bin wattch -- sources
+cargo run --quiet -p wattch-cli --bin wattch -- stream --source 1 --interval-ms 10 --duration 50ms --format csv
+cargo run --quiet -p wattch-cli --bin wattch -- run --source 1 --interval-ms 10 -- sh -c "sleep 0.05"
+```
+
+Or run the scripted end-to-end smoke check:
+
+```sh
+scripts/smoke_fake_backend.sh
 ```
 
 ## Quality gate

--- a/docs/deterministic-source.md
+++ b/docs/deterministic-source.md
@@ -1,0 +1,112 @@
+# Deterministic Source Backend
+
+Wattch can run `rapl-wattchd` with a deterministic in-memory source backend. This is intended for repeatable tests, local CLI smoke checks, and development on machines without readable Linux RAPL powercap files.
+
+It is not a real energy measurement backend.
+
+## Configuration
+
+Set `WATTCH_SOURCE_BACKEND` on the daemon process:
+
+```sh
+WATTCH_SOURCE_BACKEND=fake
+```
+
+Supported values:
+
+```text
+unset        use the default Linux powercap/RAPL backend
+powercap     use the Linux powercap/RAPL backend
+rapl         alias for the Linux powercap/RAPL backend
+fake         use the deterministic in-memory backend
+```
+
+Invalid values make `rapl-wattchd` exit during startup.
+
+The fake backend is selected by the daemon only. The CLI does not read `WATTCH_SOURCE_BACKEND`; it talks to whichever daemon is listening on `WATTCH_SOCKET`.
+
+Use `WATTCH_SOCKET` to keep local fake-backend runs isolated from the system daemon:
+
+```sh
+export WATTCH_SOCKET=/tmp/wattch-fake.sock
+```
+
+`WATTCH_POWER_CAP_ROOT` is only used by the `powercap`/`rapl` backend. The fake backend ignores powercap sysfs paths and does not require root.
+
+## Source Behavior
+
+The fake backend exposes one available source:
+
+```text
+ID  NAME                KIND  UNIT   AVAILABLE
+1   fake:deterministic  fake  joule  yes
+```
+
+The source starts at `100.0 J` and advances by `5.0 J` on every daemon read. When a stream starts, the daemon first takes an internal baseline reading, then emits samples after each requested interval:
+
+```text
+first emitted sample   energy_j=105.0  delta_j=5.0
+second emitted sample  energy_j=110.0  delta_j=5.0
+third emitted sample   energy_j=115.0  delta_j=5.0
+```
+
+Power is still computed by the normal sampler:
+
+```text
+power_w = delta_j / (interval_ns / 1_000_000_000.0)
+```
+
+For example, a `10 ms` interval produces `5 J / 0.01 s = 500 W` samples. A `100 ms` interval produces `50 W` samples.
+
+## Manual Usage
+
+Build the daemon and CLI:
+
+```sh
+cargo build -p rapl-wattchd -p wattch-cli
+```
+
+Start the daemon in one terminal:
+
+```sh
+export WATTCH_SOCKET=/tmp/wattch-fake.sock
+rm -f "$WATTCH_SOCKET"
+WATTCH_SOURCE_BACKEND=fake cargo run --quiet -p rapl-wattchd --bin rapl-wattchd
+```
+
+Use the CLI from another terminal with the same socket path:
+
+```sh
+export WATTCH_SOCKET=/tmp/wattch-fake.sock
+
+cargo run --quiet -p wattch-cli --bin wattch -- hello
+cargo run --quiet -p wattch-cli --bin wattch -- sources
+cargo run --quiet -p wattch-cli --bin wattch -- stream --source 1 --interval-ms 10 --duration 50ms --format csv
+cargo run --quiet -p wattch-cli --bin wattch -- run --source 1 --interval-ms 10 -- sh -c "sleep 0.05"
+```
+
+Stop the daemon with `Ctrl-C` when finished.
+
+## Smoke Test
+
+The repository includes an end-to-end fake-backend smoke script:
+
+```sh
+scripts/smoke_fake_backend.sh
+```
+
+The script:
+
+- builds `rapl-wattchd` and `wattch`
+- starts the daemon with `WATTCH_SOURCE_BACKEND=fake`
+- uses an isolated temporary Unix socket
+- runs `wattch hello`
+- verifies `wattch sources`
+- verifies `wattch stream`
+- verifies `wattch run`
+
+On success it prints exactly:
+
+```text
+wattch smoke test passed
+```


### PR DESCRIPTION
## Summary

- Documents how to configure `WATTCH_SOURCE_BACKEND=fake` on the daemon.
- Adds a deterministic source guide covering supported backend values, expected fake source readings, CLI usage, and the smoke script.
- Updates the README with a quick fake-backend workflow and a link to the detailed docs.

## Validation

- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace`