### PR TITLE
Archive and freeze Wattch project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@
 *.sock
 *.pid
 .codex
+
+# Local archive/audit artifacts
+/private_legal_audit/
+/docs/legal_audit/
+
 # Logs and temporary files
 *.log
 *.tmp

--- a/README.md
+++ b/README.md
@@ -14,9 +14,18 @@ The implementation intentionally contains only Rust code:
 
 ## Current status
 
-Wattch currently measures RAPL package/domain energy through the local `rapl-wattchd` daemon. It does not claim exact process-level or function-level attribution.
+Wattch is frozen and archived as of 2026-06-04. The project achieved its goal:
+checking that a small Rust daemon and Rust CLI can measure Linux RAPL
+package/domain energy through the canonical powercap interface.
+
+Wattch currently measures RAPL package/domain energy through the local
+`rapl-wattchd` daemon. It does not claim exact process-level or function-level
+attribution.
 
 The `wattch` CLI currently supports `hello`, `sources`, `stream`, and `run`.
+
+No active product development is planned. Future changes should be limited to
+critical fixes, security/dependency maintenance, or an explicit unarchive.
 
 ## v0.1-alpha scope
 
@@ -101,6 +110,13 @@ sudo ./target/debug/rapl-wattchd
 ./target/debug/wattch run -- cargo test
 ./target/debug/wattch run --format csv -- cargo test
 ```
+
+`wattch run -- <command>` is the command wrapper for energy measurement. It
+uses the same daemon connection settings as the other CLI commands: first the
+default `/etc/wattch/wattch.conf` or `WATTCH_CONFIG`, then `WATTCH_SOCKET` as an
+environment override for the socket path. The wrapper reports RAPL energy
+observed while the child command runs; it does not provide function-level or
+process-exclusive attribution.
 
 ## Quality gate
 

--- a/README.md
+++ b/README.md
@@ -12,20 +12,16 @@ The implementation intentionally contains only Rust code:
 - `wattch-core`: shared framing, validation, time, and powercap helpers
 - `wattch-proto`: protobuf types generated with `prost`
 
-## Current status
+## Status
 
-Wattch is frozen and archived as of 2026-06-04. The project achieved its goal:
-checking that a small Rust daemon and Rust CLI can measure Linux RAPL
-package/domain energy through the canonical powercap interface.
+This repository is the original Wattch v0 prototype.
 
-Wattch currently measures RAPL package/domain energy through the local
-`rapl-wattchd` daemon. It does not claim exact process-level or function-level
-attribution.
+It validated the feasibility of a local Rust-based energy measurement daemon
+and CLI using RAPL, protobuf framing, and Unix sockets.
 
-The `wattch` CLI currently supports `hello`, `sources`, `stream`, and `run`.
-
-No active product development is planned. Future changes should be limited to
-critical fixes, security/dependency maintenance, or an explicit unarchive.
+Active work is moving toward a production-oriented rewrite focused on a
+backend-independent protocol, deterministic validation, and reproducible
+measurement harnesses.
 
 ## v0.1-alpha scope
 

--- a/crates/wattch-cli/src/commands/mod.rs
+++ b/crates/wattch-cli/src/commands/mod.rs
@@ -41,6 +41,7 @@ pub enum Command {
         #[arg(long)]
         summary: bool,
     },
+    #[command(about = "Run a command while measuring daemon-reported energy")]
     Run {
         #[arg(long, default_value_t = DEFAULT_STREAM_INTERVAL_MS)]
         interval_ms: u64,

--- a/crates/wattch-cli/src/commands/run.rs
+++ b/crates/wattch-cli/src/commands/run.rs
@@ -110,7 +110,12 @@ fn observe_sample(
 
 fn expect_start_stream(response: Response) -> Result<(), Box<dyn std::error::Error>> {
     match response.kind {
-        Some(response::Kind::StartStream(_)) => Ok(()),
+        Some(response::Kind::StartStream(start)) if start.started => Ok(()),
+        Some(response::Kind::StartStream(start)) => Err(format!(
+            "daemon stream already active at interval {} ns",
+            start.effective_interval_ns
+        )
+        .into()),
         Some(response::Kind::Error(error)) => {
             Err(format!("daemon error {}: {}", error.code, error.message).into())
         }

--- a/crates/wattch-cli/tests/cli_smoke.rs
+++ b/crates/wattch-cli/tests/cli_smoke.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use assert_cmd::Command;
-use predicates::str::contains;
+use predicates::str::{contains, is_empty};
 use tempfile::TempDir;
 use tokio::net::UnixListener;
 use wattch_core::{read_frame_async, write_frame_async};
@@ -130,9 +130,60 @@ async fn spawn_fake_daemon(socket: &Path) -> tokio::task::JoinHandle<()> {
     })
 }
 
+async fn spawn_fake_busy_daemon(socket: &Path) -> tokio::task::JoinHandle<()> {
+    let listener = UnixListener::bind(socket).expect("bind fake daemon socket");
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept cli");
+        loop {
+            let request: Request = match read_frame_async(&mut stream).await {
+                Ok(request) => request,
+                Err(_) => break,
+            };
+
+            match request.kind {
+                Some(request::Kind::ListSources(_)) => {
+                    write_frame_async(
+                        &mut stream,
+                        &Response {
+                            request_id: request.request_id,
+                            kind: Some(response::Kind::ListSources(ListSourcesResponse {
+                                sources: sources(),
+                            })),
+                        },
+                    )
+                    .await
+                    .expect("write sources");
+                }
+                Some(request::Kind::StartStream(_)) => {
+                    write_frame_async(
+                        &mut stream,
+                        &Response {
+                            request_id: request.request_id,
+                            kind: Some(response::Kind::StartStream(StartStreamResponse {
+                                started: false,
+                                effective_interval_ns: 100_000_000,
+                            })),
+                        },
+                    )
+                    .await
+                    .expect("write busy start");
+                }
+                _ => {}
+            }
+        }
+    })
+}
+
 fn wattch(socket: &Path) -> Command {
     let mut command = Command::cargo_bin("wattch").expect("cli binary");
     command.env("WATTCH_SOCKET", socket);
+    command
+}
+
+fn wattch_with_config(config_path: &Path) -> Command {
+    let mut command = Command::cargo_bin("wattch").expect("cli binary");
+    command.env("WATTCH_CONFIG", config_path);
+    command.env_remove("WATTCH_SOCKET");
     command
 }
 
@@ -248,6 +299,46 @@ async fn cli_run_executes_command_and_prints_summary() {
         .stdout(contains("rapl:package-0"));
 
     fake_daemon.await.expect("fake daemon task");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cli_run_uses_socket_from_config_file() {
+    let temp = TempDir::new().expect("tempdir");
+    let socket = socket_path(&temp);
+    let config_path = temp.path().join("wattch.conf");
+    std::fs::write(
+        &config_path,
+        format!("socket_path = \"{}\"\n", socket.display()),
+    )
+    .expect("write config");
+    let fake_daemon = spawn_fake_daemon(&socket).await;
+
+    wattch_with_config(&config_path)
+        .args(["run", "--", "sh", "-c", "sleep 0.08"])
+        .assert()
+        .success()
+        .stdout(contains("Command: sh -c sleep 0.08"))
+        .stdout(contains("rapl:package-0"));
+
+    fake_daemon.await.expect("fake daemon task");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cli_run_refuses_to_execute_when_daemon_stream_is_busy() {
+    let temp = TempDir::new().expect("tempdir");
+    let socket = socket_path(&temp);
+    let fake_daemon = spawn_fake_busy_daemon(&socket).await;
+
+    wattch(&socket)
+        .args(["run", "--", "sh", "-c", "echo should-not-run"])
+        .assert()
+        .failure()
+        .stdout(is_empty())
+        .stderr(contains(
+            "daemon stream already active at interval 100000000 ns",
+        ));
+
+    fake_daemon.abort();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/docs/ARCHIVE.md
+++ b/docs/ARCHIVE.md
@@ -1,0 +1,51 @@
+# Wattch Archive Record
+
+Status: frozen and archived.
+
+Archive date: 2026-06-04.
+
+Reason: Wattch achieved its intended goal: validate that a minimal Rust daemon
+and Rust CLI can discover Linux RAPL powercap sources, read cumulative
+`energy_uj` counters, compute energy/power deltas, and expose those samples over
+a local protobuf Unix-socket protocol.
+
+## Frozen Scope
+
+The archived project scope is:
+
+- Rust daemon: `rapl-wattchd`
+- Rust CLI: `wattch`
+- Shared Rust crates: `wattch-core` and `wattch-proto`
+- Protobuf length-prefixed Unix-socket wire protocol
+- RAPL powercap discovery under `/sys/devices/virtual/powercap`
+- CLI commands: `hello`, `sources`, `stream`, and `run`
+- Deterministic tests using fake powercap trees and fake daemons
+
+The archived project intentionally does not include other clients, dashboards,
+HTTP/gRPC APIs, databases, report generation, AI integrations, profiler
+integrations, or plugin systems.
+
+## Maintenance Policy
+
+Do not expand the product surface while the project is archived. Acceptable
+future changes are limited to:
+
+- Critical correctness fixes
+- Security or dependency maintenance
+- Build or CI fixes needed to keep the archived project reproducible
+- Documentation clarifications that do not change scope
+
+Any feature work should first explicitly unarchive the project and update this
+record.
+
+## Verification Gate
+
+Before treating the archived state as valid, run:
+
+```sh
+cargo metadata --locked --no-deps --format-version 1 > /dev/null
+cargo fmt --all --check
+cargo clippy --locked --workspace --all-targets -- -D warnings
+cargo test --locked --workspace
+cargo build --locked --workspace
+```


### PR DESCRIPTION
Revise project status to reflect the completion of goals and clarify the maintenance policy for the archived state. Include documentation for the frozen scope and verification requirements.